### PR TITLE
fix wrong port in docker command

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -86,7 +86,7 @@ The Docker documentation is a good starting point for understanding the differen
 
 ```shell
 docker run --name some-sftpgo \
-    -p 8080:8090 \
+    -p 8080:8080 \
     -p 2022:2022 \
     --mount type=bind,source=/my/own/sftpgodata,target=/srv/sftpgo \
     --mount type=bind,source=/my/own/sftpgohome,target=/var/lib/sftpgo \


### PR DESCRIPTION
I just tried running SFTPGo and noticed that the Web UI was not coming up. This PR fixes a wrong port in the sample command for Docker. Hope this helps because i struggled for like 30 minutes before i noticed what had happend.